### PR TITLE
Fixes for compilation under Cygwin

### DIFF
--- a/common_funcs.cpp
+++ b/common_funcs.cpp
@@ -31,7 +31,7 @@ unsigned int str_to_uint(const std::string str)
 
 std::string uint_to_str(unsigned int num)
 {
-	std::ostringstream stream;
-	stream << num;
-	return stream.str();
+    std::ostringstream stream;
+    stream << num;
+    return stream.str();
 }

--- a/common_funcs.cpp
+++ b/common_funcs.cpp
@@ -2,6 +2,7 @@
 #include "common_types.h"
 
 #include <memory>
+#include <sstream>
 
 #include "polarssl/sha256.h"
 
@@ -17,4 +18,20 @@ bool CompareHash(const u8* data_buf, const size_t data_size, const u8* hash_buf)
     std::unique_ptr<u8> generated_hash(new u8[32]);
     sha256(data_buf, data_size, generated_hash.get(), 0);
     return memcmp(generated_hash.get(), hash_buf, 32) == 0;
+}
+
+unsigned int str_to_uint(const std::string str)
+{
+    char * end;
+    unsigned int val = strtoul(str.c_str(), &end, 0);
+    if (*end != '\0')
+        throw std::invalid_argument("Invalid string");
+    return val;
+}
+
+std::string uint_to_str(unsigned int num)
+{
+	std::ostringstream stream;
+	stream << num;
+	return stream.str();
 }

--- a/common_funcs.h
+++ b/common_funcs.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <map>
 #include <algorithm>
+#include <string>
 
 #include "common_types.h"
 
@@ -14,6 +15,9 @@
 void XOR(u8* target_buf, const u8* xorpad, const size_t size);
 
 bool CompareHash(const u8* data_buf, const size_t data_size, const u8* hash_buf);
+
+unsigned int str_to_uint(const std::string str);
+std::string uint_to_str(unsigned int num);
 
 template <typename AT, typename T>
 bool Found(const std::vector<AT>& vec, T item) {

--- a/file_io.cpp
+++ b/file_io.cpp
@@ -1,4 +1,5 @@
 #include "file_io.h"
+#include <cstdio>
 
 size_t WriteBinaryFile(const std::string& filename, const void* buffer, const size_t buf_size)
 {

--- a/ncch.cpp
+++ b/ncch.cpp
@@ -1,25 +1,25 @@
 #include "ncch.h"
 
-#include <string>
+#include <iostream>
 
 #include "common_funcs.h"
 
 bool NCCH::DecryptExheader(const std::vector<u8>& xorpad)
 {
     if (xorpad.empty()) {
-        printf("ERROR: Input exheader XORPad does not exist!\n");
+        std::cerr << "ERROR: Input exheader XORPad does not exist!\n";
         return false;
     }
 
     u8* exheader = &buffer[NCCH::OFFSET_EXHEADER];
     if (xorpad.size() < 0x800) {
-        printf("ERROR: Exheader XORPad invalid!\n");
+        std::cerr << "ERROR: Exheader XORPad invalid!\n";
         return false;
     }
 
     XOR(exheader, xorpad.data(), 0x800);
     if (!CompareHash(exheader, 0x400, &buffer[NCCH_Header::OFFSET_EXHEADER_HASH])) {
-        printf("ERROR: Exheader XORPad invalid!\n");
+        std::cerr << "ERROR: Exheader XORPad invalid!\n";
         return false;
     }
     return true;
@@ -28,20 +28,20 @@ bool NCCH::DecryptExheader(const std::vector<u8>& xorpad)
 bool NCCH::DecryptEXEFS(const std::vector<u8>& xorpad)
 {
     if (xorpad.empty()) {
-        printf("ERROR: Input EXEFS XORPad does not exist!\n");
+        std::cerr << "ERROR: Input EXEFS XORPad does not exist!\n";
         return false;
     }
 
     u8* exefs = &buffer[header.GetExefsOffset()];
     if (xorpad.size() < header.GetExefsSize()) {
-        printf("ERROR: EXEFS XORPad invalid!\n");
+        std::cerr << "ERROR: EXEFS XORPad invalid!\n";
         return false;
     }
 
     XOR(exefs, &xorpad[0], header.GetExefsSize());
 
     if (!CompareHash(exefs, header.GetExefsHashSize(), &buffer[NCCH_Header::OFFSET_EXEFS_HASH])) {
-        printf("ERROR: EXEFS XORPad invalid!\n");
+        std::cerr << "ERROR: EXEFS XORPad invalid!\n";
         return false;
     }
     return true;
@@ -50,18 +50,18 @@ bool NCCH::DecryptEXEFS(const std::vector<u8>& xorpad)
 bool NCCH::DecryptEXEFS(const std::vector<u8>& xorpad_normal, const std::vector<u8>& xorpad_7x)
 {
     if (xorpad_normal.empty()) {
-        printf("ERROR: Input EXEFS normal XORPad does not exist!\n");
+        std::cerr << "ERROR: Input EXEFS normal XORPad does not exist!\n";
         return false;
     }
 
     if (xorpad_7x.empty()) {
-        printf("ERROR: Input EXEFS 7.x XORPad does not exist!\n");
+        std::cerr << "ERROR: Input EXEFS 7.x XORPad does not exist!\n";
         return false;
     }
 
     u8* exefs_buf = &buffer[header.GetExefsOffset()];
     if (xorpad_normal.size() + xorpad_7x.size() < header.GetExefsSize()) {
-        printf("ERROR: EXEFS XORPads invalid!\n");
+        std::cerr << "ERROR: EXEFS XORPads invalid!\n";
         return false;
     }
 
@@ -83,7 +83,7 @@ bool NCCH::DecryptEXEFS(const std::vector<u8>& xorpad_normal, const std::vector<
 
     if (!exefs.VerifyHashes() ||
         !CompareHash(exefs_buf, header.GetExefsHashSize(), &buffer[NCCH_Header::OFFSET_EXEFS_HASH])) {
-        printf("ERROR: EXEFS XORPads invalid!\n");
+        std::cerr << "ERROR: EXEFS XORPads invalid!\n";
         return false;
     }
     return true;
@@ -92,20 +92,20 @@ bool NCCH::DecryptEXEFS(const std::vector<u8>& xorpad_normal, const std::vector<
 bool NCCH::DecryptROMFS(const std::vector<u8>& xorpad)
 {
     if (xorpad.empty()) {
-        printf("ERROR: Input ROMFS XORPad does not exist!\n");
+        std::cerr << "ERROR: Input ROMFS XORPad does not exist!\n";
         return false;
     }
 
     u8* romfs = &buffer[header.GetRomfsOffset()];
     if (xorpad.size() < header.GetRomfsSize()) {
-        printf("ERROR: ROMFS XORPad invalid!\n");
+        std::cerr << "ERROR: ROMFS XORPad invalid!\n";
         return false;
     }
 
     XOR(romfs, &xorpad[0], header.GetRomfsSize());
 
     if (!CompareHash(romfs, header.GetRomfsHashSize(), &buffer[NCCH_Header::OFFSET_ROMFS_HASH])) {
-        printf("ERROR: ROMFS XORPad invalid!\n");
+        std::cerr << "ERROR: ROMFS XORPad invalid!\n";
         return false;
     }
     return true;


### PR DESCRIPTION
Basically this PR:
- Uses `std::cerr` instead of `printf` for errors, which is more C++-ish. Also it keeps stdout free for debugging or logging.
- Does not use `std::to_string` or `std::stoi`, which are features from C++11 which are not yet widely implemented. Namely, MingW does not have them implemented yet. I've replaced them with two small functions which do exactly the same using standard C and C++ functions.
- Replaced `char *` for optlist with `std::string`, standarizing the code so there's no mess of mixed C with C++ strings.
- Added a few missing headers (for instance `cstdio` for `fopen` and friends in `file_io.cpp`), as apparenly your setup adds them by default to the compilation environment, but mine did not.
